### PR TITLE
remove extraneous argument to use_ok

### DIFF
--- a/t/entry.t
+++ b/t/entry.t
@@ -18,7 +18,7 @@ use Test::More tests => 41;
 my $class;
 BEGIN { 
 	$class = 'Text::Todo::Entry';
-	use_ok( $class, "use $class" ) 
+	use_ok( $class );
 }
 
 diag("Testing entry $class $Text::Todo::Entry::VERSION");

--- a/t/list.t
+++ b/t/list.t
@@ -23,7 +23,7 @@ my $class;
 
 BEGIN {
     $class = 'Text::Todo';
-    use_ok( $class, "use $class" );
+    use_ok( $class );
 }
 
 diag("Testing entry $class $Text::Todo::VERSION");

--- a/t/read_todo.t
+++ b/t/read_todo.t
@@ -83,7 +83,7 @@ my %extra_todo = (
     done     => undef,
 );
 
-BEGIN { use_ok( 'Text::Todo', 'use Text::Todo' ) }
+BEGIN { use_ok( 'Text::Todo' ) }
 
 diag("Testing read Text::Todo $Text::Todo::VERSION");
 

--- a/t/special_tags.t
+++ b/t/special_tags.t
@@ -18,7 +18,7 @@ use Test::More tests => 30;
 my $class;
 BEGIN { 
 	$class = 'Text::Todo::Entry';
-	use_ok( $class, "use $class" ) 
+	use_ok( $class );
 }
 
 diag("Testing special tags in $class $Text::Todo::Entry::VERSION");


### PR DESCRIPTION
use_ok does not accept a test name, but passes its extra arguments to the module's import method. Perl has always ignored these extraneous arguments, but future versions are intending to make it an error to pass arguments to an undefined import method.